### PR TITLE
Add KB schema and seed marker sets

### DIFF
--- a/kb/schema/marker.schema.json
+++ b/kb/schema/marker.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Marker Set Schema",
+  "type": "object",
+  "properties": {
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "keywords": {
+      "type": "array",
+      "items": { "type": "string" },
+      "minItems": 1
+    },
+    "semanticHints": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "promptInserts": {
+      "type": "object",
+      "properties": {
+        "de": { "type": "string" },
+        "en": { "type": "string" }
+      },
+      "required": ["de", "en"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["version", "keywords", "semanticHints", "promptInserts"],
+  "additionalProperties": false
+}

--- a/kb/sets/ambivalenz.json
+++ b/kb/sets/ambivalenz.json
@@ -1,0 +1,15 @@
+{
+  "version": "1.0.0",
+  "keywords": [
+    "ambivalent",
+    "zwiespältig",
+    "doppeldeutig",
+    "innerer Konflikt",
+    "unsicher"
+  ],
+  "semanticHints": [],
+  "promptInserts": {
+    "de": "zeigt innere Zerrissenheit",
+    "en": "shows inner conflict"
+  }
+}

--- a/kb/sets/schuld.json
+++ b/kb/sets/schuld.json
@@ -1,0 +1,15 @@
+{
+  "version": "1.0.0",
+  "keywords": [
+    "Schuld",
+    "verantwortlich",
+    "Schuldgefühl",
+    "Reue",
+    "Sühne"
+  ],
+  "semanticHints": [],
+  "promptInserts": {
+    "de": "weist auf Schuld hin",
+    "en": "indicates guilt"
+  }
+}


### PR DESCRIPTION
## Summary
- add KB schema for marker sets
- seed example marker sets `ambivalenz` and `schuld`

## Testing
- `pip install jsonschema==4`
- `jsonschema kb/schema/marker.schema.json -i kb/sets/ambivalenz.json`
- `jsonschema kb/schema/marker.schema.json -i kb/sets/schuld.json`


------
https://chatgpt.com/codex/tasks/task_b_687120b6052c8322a2696532a05afa48