### PR TITLE
Add KB schema and sample marker sets

### DIFF
--- a/kb/schema/marker.schema.json
+++ b/kb/schema/marker.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Marker Definition",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "keywords", "semanticHints", "promptInserts"],
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "label": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "keywords": {
+      "type": "array",
+      "minItems": 3,
+      "items": {"type": "string"}
+    },
+    "semanticHints": {
+      "type": "array",
+      "items": {"type": "string"},
+      "default": []
+    },
+    "promptInserts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["de", "en"],
+      "properties": {
+        "de": {"type": "string"},
+        "en": {"type": "string"}
+      }
+    }
+  }
+}

--- a/kb/sets/ambivalenz.json
+++ b/kb/sets/ambivalenz.json
@@ -1,0 +1,15 @@
+{
+  "id": "ambivalenz",
+  "label": "Ambivalenz",
+  "version": "1.0.0",
+  "keywords": [
+    "ambivalent",
+    "zwiespältig",
+    "innerer Konflikt"
+  ],
+  "semanticHints": [],
+  "promptInserts": {
+    "de": "zeige Ambivalenz",
+    "en": "show ambivalence"
+  }
+}

--- a/kb/sets/schuld.json
+++ b/kb/sets/schuld.json
@@ -1,0 +1,15 @@
+{
+  "id": "schuld",
+  "label": "Schuld",
+  "version": "1.0.0",
+  "keywords": [
+    "Schuld",
+    "Fehler",
+    "Reue"
+  ],
+  "semanticHints": [],
+  "promptInserts": {
+    "de": "Gefühl von Schuld",
+    "en": "sense of guilt"
+  }
+}


### PR DESCRIPTION
## Summary
- add KB marker schema
- provide `ambivalenz` and `schuld` marker example sets

## Testing
- `pip install jsonschema==4`
- `jsonschema -i kb/sets/ambivalenz.json kb/schema/marker.schema.json`
- `jsonschema -i kb/sets/schuld.json kb/schema/marker.schema.json`


------
https://chatgpt.com/codex/tasks/task_b_687120b6052c8322a2696532a05afa48